### PR TITLE
Changed tests for FASTQ output from qual.n to com.n

### DIFF
--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -92,6 +92,7 @@ int cFQ::readRecord(RECORD *pRecord)
 		// read fasta instead
 		char c = fgetc(in);
 		pRecord->seq.n = 0;
+		pRecord->com.n = 0;
 		while (c != '>' && c != EOF) {
 			if (pRecord->seq.a <= size_t(pRecord->seq.n+1)) {
 				pRecord->seq.s=(char *)realloc(pRecord->seq.s, pRecord->seq.a=(pRecord->seq.a * 3 / 2 + 64));

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -277,7 +277,7 @@ enum FASTQ_FORMAT gzformat(char * fileNames[], int nFileCnt)
 		fq.associateFile(cf.fp);
 		format_new = UNKNOWN_FASTQ;
 		while(fq.readRecord() > 0){
-			if(fq.rec.qual.n == 0){
+			if(fq.rec.com.n == 0){
 				format_new = FASTA;
 				break;
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -827,20 +827,20 @@ void * mt_worker(void * data)
 					}
 				}
 				if(bDontTrim){
-					if(pRecord->qual.n > 0) // fastq
+					if(pRecord->com.n > 0 ) // fastq
 						fprintf(fpOut, "@%s%s\n+\n%s\n", pRecord->id.s, pRecord->seq.s, pRecord->qual.s);
 					else // fasta
 						fprintf(fpOut, ">%s%s\n", pRecord->id.s, pRecord->seq.s);
 				}
 				else{
 					if(bFivePrimeEnd){
-						if(pRecord->qual.n > 0) // fastq
+						if(pRecord->com.n > 0 ) // fastq
 							fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s + pRecord->seq.n - pos, pos, pRecord->qual.s + pRecord->qual.n - pos);
 						else // fasta
 							fprintf(fpOut, ">%s%.*s\n", pRecord->id.s, pos, pRecord->seq.s + pRecord->seq.n - pos);
 					}
 					else{
-						if(pRecord->qual.n > 0) // fastq
+						if(pRecord->com.n > 0) // fastq
 							fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s, pos, pRecord->qual.s);
 						else // fasta
 							fprintf(fpOut, ">%s%.*s\n", pRecord->id.s, pos, pRecord->seq.s);
@@ -1049,7 +1049,7 @@ void * mt_worker2(void * data)
 				}
 				rLen = pRecord->seq.n;
 				qLen = pRecord->qual.n;
-				if(qLen > 0){ // fastq
+				if(pRecord->com.n > 0){ // fastq
 					fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s, pos, pRecord->qual.s);
 					fprintf(fpOut2, "@%s%.*s\n+\n%.*s\n", pRecord2->id.s, pos2, pRecord2->seq.s, pos2, pRecord2->qual.s);
 				}
@@ -1253,13 +1253,13 @@ void * mt_worker2_sep(void * data)
 					}
 				}
 				if(bFivePrimeEnd){
-					if( pRecord->qual.n > 0 ){ // fastq
+					if( pRecord->com.n > 0 ){ // fastq
 						fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s + pRecord->seq.n - pos, pos, pRecord->qual.s + pRecord->qual.n - pos);
 					}
 					else{ // fasta
 						fprintf(fpOut, ">%s%.*s\n", pRecord->id.s, pos, pRecord->seq.s + pRecord->seq.n - pos);
 					}
-					if( pRecord2->qual.n > 0 ){ // fastq
+					if( pRecord2->com.n > 0 ){ // fastq
 						fprintf(fpOut2, "@%s%.*s\n+\n%.*s\n", pRecord2->id.s, pos2, pRecord2->seq.s + pRecord2->seq.n - pos2, pos2, pRecord2->qual.s + pRecord2->qual.n - pos2);
 					}
 					else{ // fasta
@@ -1267,13 +1267,13 @@ void * mt_worker2_sep(void * data)
 					}
 				}
 				else{
-					if( pRecord->qual.n > 0 ){ // fastq
+					if( pRecord->com.n > 0 ){ // fastq
 						fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s, pos, pRecord->qual.s);
 					}
 					else{ // fasta
 						fprintf(fpOut, ">%s%.*s\n", pRecord->id.s, pos, pRecord->seq.s);
 					}
-					if( pRecord2->qual.n > 0 ){ // fastq
+					if( pRecord2->com.n > 0 ){ // fastq
 						fprintf(fpOut2, "@%s%.*s\n+\n%.*s\n", pRecord2->id.s, pos2, pRecord2->seq.s, pos2, pRecord2->qual.s);
 					}
 					else{ // fasta
@@ -1483,13 +1483,13 @@ void * mt_worker2_amp(void * data)
 					}
 				}
 				if(bFivePrimeEnd){
-					if( pRecord->qual.n > 0 ){ // fastq
+					if( pRecord->com.n > 0 ){ // fastq
 						fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s + pRecord->seq.n - pos, pos, pRecord->qual.s + pRecord->qual.n - pos);
 					}
 					else{ // fasta
 						fprintf(fpOut, ">%s%.*s\n", pRecord->id.s, pos, pRecord->seq.s + pRecord->seq.n - pos);
 					}
-					if( pRecord2->qual.n > 0 ){ // fastq
+					if( pRecord2->com.n > 0 ){ // fastq
 						fprintf(fpOut2, "@%s%.*s\n+\n%.*s\n", pRecord2->id.s, pos2, pRecord2->seq.s + pRecord2->seq.n - pos2, pos2, pRecord2->qual.s + pRecord2->qual.n - pos2);
 					}
 					else{ // fasta
@@ -1497,13 +1497,13 @@ void * mt_worker2_amp(void * data)
 					}
 				}
 				else{
-					if( pRecord->qual.n > 0 ){ // fastq
+					if( pRecord->com.n > 0 ){ // fastq
 						fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s, pos, pRecord->qual.s);
 					}
 					else{ // fasta
 						fprintf(fpOut, ">%s%.*s\n", pRecord->id.s, pos, pRecord->seq.s);
 					}
-					if( pRecord2->qual.n > 0 ){ // fastq
+					if( pRecord2->com.n > 0 ){ // fastq
 						fprintf(fpOut2, "@%s%.*s\n+\n%.*s\n", pRecord2->id.s, pos2, pRecord2->seq.s, pos2, pRecord2->qual.s);
 					}
 					else{ // fasta
@@ -1804,7 +1804,7 @@ void * mt_worker3(void * data)
 				}
 				rLen = pRecord->seq.n;
 				qLen = pRecord->qual.n;
-				if(qLen > 0){ // fastq
+				if( pRecord->com.n > 0 ){ // fastq
 					if(pos <= rLen){
 						fprintf(fpOut, "@%s%.*s\n+\n%.*s\n", pRecord->id.s, pos, pRecord->seq.s, pos, pRecord->qual.s);
 					}


### PR DESCRIPTION
This change prevents corrupt output (mixed fasta and fastq records) when encountering input fastq records with zero-length sequences.

com.n is a more reliable format indicator; it is definitiively zero with FASTA input and definitively nonzero with FASTQ input, regardless of the sequence length and quality legnth.  
