### PR TITLE
Move -lrt argument to the end of gcc command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 CXX=g++
 DEBUG?=0
 CXXFLAGS?=-c
-LDFLAGS=-pthread -lrt
+LDFLAGS=-pthread
+LDLIBS=-lrt
 ifneq ($(OS), Windows_NT)
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S), Darwin)
-		LDFLAGS=-lpthread
+		LDLIBS=
 	endif
 endif
 SRC=src
@@ -27,7 +28,7 @@ debug:
 	$(MAKE) $(MAKEFILE) DEBUG=1
 
 $(EXECUTABLE):$(OBJECTS)
-	$(CXX) $(LDFLAGS) $(OBJECTS) -o $@
+	$(CXX) $(LDFLAGS) $(OBJECTS) -o $@ $(LDLIBS)
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) $< -o $@


### PR DESCRIPTION
Fixes Issue #7, fails to compile on Ubuntu 12.04 precise with the error 

    undefined reference to `clock_gettime' 

Tested on precise, trusty, and apple gcc version 4.2.1

The -lrt argument (link against real-time-clock library) must be at the end of the g++ command line for some versions of gcc.