### PR TITLE
New optional output files, "fill with N's" option

### DIFF
--- a/src/fastq.h
+++ b/src/fastq.h
@@ -67,7 +67,8 @@ typedef enum{
 	TAG_EMPTY = 3,
 	TAG_SHORT = 4,
 	TAG_CONTAMINANT = 5,
-	TAG_UNDETERMINED = 6
+	TAG_UNDETERMINED = 6,
+	TAG_LONG = 7
 }REC_TAG;
 
 typedef struct tag_REC{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@
 
 using namespace std;
 
-const char * TAG_NAME[TAG_CNT] = { "NORMAL", "BLURRY", "BADQUAL", "EMPTY", "SHORT", "CONTAMINANT", "UNDETERMINED", "LONG" };
+const char * TAG_NAME[8] = { "NORMAL", "BLURRY", "BADQUAL", "EMPTY", "SHORT", "CONTAMINANT", "UNDETERMINED", "LONG" };
 
 class cStats
 {

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -75,8 +75,22 @@ public:
 	vector<string> colNames;
 	vector<string> juncAdapters;
 	char * input[2];
+	// These are the output fastq files for the
+	// trimmed reads that pass filters
 	vector<string> output;
 	vector<string> output2;
+	// These are the output fastq files for only
+	// the reads that passed filters AND were trimmed.
+	// The full reads appear in the file with the
+	// trimmed bases in lower case rather than removed.
+	vector<string> masked;
+	vector<string> masked2;
+	bool bWriteMasked;
+	// These files contain the reads that were excluded
+	// from the output because they failed filters.
+	vector<string> excluded;
+	vector<string> excluded2;
+	bool bWriteExcluded;
 	vector<string> barcodeNames;
 	string barcodes;
 	string mapfile;
@@ -105,6 +119,7 @@ public:
 	int minK;
 	int iCutF, iCutR;
 	bool bCutTail;
+	bool bFillWithNs;
 
 private:
 	char * occOfLastDot(char * str);


### PR DESCRIPTION
I added two new optional output files:
1) Masked: output file(s) for trimmed reads, with trimmed bases converted to lower case
2) Excluded: output file(s) for reads excluded by filters

I also added an option to replace trimmed bases with N’s, for programs that require all reads to be of the same length.

Finally, I added a new tag (TAG_LONG), and I made sure that all excluded reads have the correct tag assigned. I output the tag to the excluded file(s).