### PR TITLE
Add option to hard-clip the 3' end of read(s)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,6 +167,8 @@ public:
 	bool bFillWithNs;
 	bool bCutTail;
 	int iCutF, iCutR;
+	bool bClipTail;
+	int iClip1, iClip2;
 
 	int getMinLen(){
 		return int(minLen);
@@ -192,6 +194,8 @@ public:
 		maxLen = INT_MAX;
 		nBarcodes = 0;
 		iCutF = iCutR = 0;
+		bClipTail = false;
+		iClip1 = iClip2 = 0;
 		pDecorate = "";
 		
 		fpOuts = fpOuts2 = NULL;
@@ -267,6 +271,8 @@ public:
 		nBarcodes = 0;
 		this->iCutF = pParameter->iCutF;
 		this->iCutR = pParameter->iCutR;
+		this->iClip1 = pParameter->iClip1;
+		this->iClip2 = pParameter->iClip2;
 		if(!pParameter->bBarcode)
 			return true;
 		pBarcode = new long[pParameter->output.size()];
@@ -311,6 +317,7 @@ public:
 		this->bFilterUndetermined = pParameter->bFilterUndetermined;
 		this->bRedistribute = pParameter->bRedistribute;
 		this->bCutTail = pParameter->bCutTail;
+		this->bClipTail = pParameter->bClipTail;
 		this->bFillWithNs = pParameter->bFillWithNs;
 	}
 	bool openOutputFiles(cParameter * pParameter){
@@ -899,6 +906,8 @@ void * mt_worker(void * data)
 	bool bFivePrimeEnd = pStats->bFivePrimeEnd;
 	bool bBarcode = pStats->bBarcode;
 	bool bCutTail = pStats->bCutTail;
+	bool bClipTail = pStats->bClipTail;
+	int iClip1 = pStats->iClip1;
 	
 	RECORD * pBuffer, *pRecord;
 	TASK task;
@@ -968,6 +977,9 @@ void * mt_worker(void * data)
 				pRecord->idx = cMatrix::findAdapter(pRecord->seq.s, pRecord->seq.n, (uchar *)pRecord->qual.s, pRecord->qual.n);
 				if(pRecord->idx.pos < 0){
 					pRecord->idx.pos = 0;
+				}
+				if(bClipTail && iClip1 > 0 && (pRecord->idx.pos > 0)) {
+					pRecord->idx.pos = max(0, pRecord->idx.pos - iClip1);
 				}
 				if( (minEndQual > 0) && (pRecord->idx.pos > 0) && (pRecord->qual.n > 0) ){ // not found
 					pRecord->idx.pos = cMatrix::trimByQuality((uchar *)pRecord->qual.s, min(pRecord->idx.pos, pRecord->qual.n), minEndQual);
@@ -1325,7 +1337,10 @@ void * mt_worker2(void * data)
 	int maxLen = pStats->getMaxLen();
 	bool bBarcode = pStats->bBarcode;
 	bool bCutTail = pStats->bCutTail;
-
+	bool bClipTail = pStats->bClipTail;
+	int iClip1 = pStats->iClip1;
+	int iClip2 = pStats->iClip2;
+	
 	RECORD *pBuffer, *pRecord, *pRecord2;
 	TASK task;
 	int size2, rc, rc2, nItemCnt, nCnt;
@@ -1418,6 +1433,14 @@ void * mt_worker2(void * data)
 						if( cMatrix::isBlurry(pRecord->seq.s, rLen) && cMatrix::isBlurry(pRecord2->seq.s, rLen) ){
 							pRecord->tag = pRecord2->tag = TAG_BLURRY;
 						}
+					}
+				}
+				if(bClipTail && (pRecord->tag == TAG_NORMAL)) {
+					if (iClip1 > 0 && (pRecord->idx.pos > 0)) {
+						pRecord->idx.pos = max(0, pRecord->idx.pos - iClip1);
+					}
+					if (iClip2 > 0 && (pRecord2->idx.pos > 0)) {
+						pRecord2->idx.pos = max(0, pRecord2->idx.pos - iClip2);
 					}
 				}
 				if( (minEndQual > 0) && (pos > 0) && (pRecord->tag == TAG_NORMAL) ){ // trimmed by quality
@@ -1574,7 +1597,10 @@ void * mt_worker2_sep(void * data)
 	bool bFivePrimeEnd = pStats->bFivePrimeEnd;
 	bool bBarcode = pStats->bBarcode;
 	bool bCutTail = pStats->bCutTail;
-
+	bool bClipTail = pStats->bClipTail;
+	int iClip1 = pStats->iClip1;
+	int iClip2 = pStats->iClip2;
+	
 	RECORD *pBuffer, *pRecord, *pRecord2;
 	TASK task;
 	int size2, rc, rc2, nItemCnt, nCnt;
@@ -1655,6 +1681,14 @@ void * mt_worker2_sep(void * data)
 				}
 				if(pRecord2->idx.pos < 0){
 					pRecord2->idx.pos = 0;
+				}
+				if(bClipTail) {
+					if (iClip1 > 0 && (pRecord->idx.pos > 0)) {
+						pRecord->idx.pos = max(0, pRecord->idx.pos - iClip1);
+					}
+					if (iClip2 > 0 && (pRecord2->idx.pos > 0)) {
+						pRecord2->idx.pos = max(0, pRecord2->idx.pos - iClip2);
+					}
 				}
 				if( minEndQual > 0 ){
 					if( (pRecord->idx.pos > 0) && (pRecord->qual.n > 0) ){
@@ -2106,6 +2140,7 @@ void * mt_worker2_mp(void * data)
 	int maxLen2 = (maxLen == INT_MAX) ? INT_MAX : (maxLen * 2);
 	bool bBarcode = pStats->bBarcode;
 	bool bCutTail = pStats->bCutTail;
+	bool bClipTail = pStats->bClipTail;
 	bool bRedistribute = pStats->bRedistribute;
 
 	RECORD *pBuffer, *pRecord, *pRecord2;

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -160,6 +160,8 @@ cParameter::cParameter()
 
 	iCutF = iCutR = 0;
 	bCutTail = false;
+	bClipTail = false;
+	iClip1 = iClip2 = 0;
 	
 	bWriteExcluded = false;
 	bFillWithNs = false;
@@ -356,6 +358,9 @@ void cParameter::PrintUsage(char * program, FILE * fp)
 	fprintf(fp, "          -c, --cut <int>,<int> Hard clip off the 5' leading bases as the barcodes in amplicon mode; (no)\n");
 	fprintf(fp, "          -e, --cut3            Hard clip off the 3' tailing bases if the read length is greater than\n");
 	fprintf(fp, "                                the maximum read length specified by -L; (no)\n");
+	fprintf(fp, "          -p, --clip3 <int>[,<int>] Hard clip off specified numbers of bases from 3' end of first read (and\n");
+	fprintf(fp, "                                    second read, if paired-end) before performing any other clipping. Ignored\n");
+	fprintf(fp, "                                    in amplicon and mate-pair modes; (no)\n");
 	fprintf(fp, " Filtering:\n");
 	fprintf(fp, "          -q, --end-quality  <int> Trim 3' end until specified or higher quality reached; (0)\n");
 	fprintf(fp, "          -Q, --mean-quality <int> The lowest mean quality value allowed before trimming; (0)\n");
@@ -546,7 +551,7 @@ void cParameter::printOpt(FILE * fp, bool bLeadingRtn)
 
 int cParameter::GetOpt(int argc, char *argv[], char * errMsg)
 {
-	const char *options = "x:y:j:m:r:d:q:l:L:M:nuf:bc:e#o:z1Q:k:t:i*vhAXN";
+	const char *options = "x:y:j:m:r:d:q:l:L:M:nuf:bc:e#o:z1Q:k:t:i*vhAXNp:";
 	OPTION_ITEM longOptions[] = {
 		{"barcode", 'b'},
 		{"mode", 'm'},
@@ -562,6 +567,7 @@ int cParameter::GetOpt(int argc, char *argv[], char * errMsg)
 		{"compress", 'z'},
 		{"cut", 'c'}, // hard clip for clipping 6bp or 8bp tags from amplicon reads
 					  // example: --cut 0,6 for cutting leading 6 bp from read matches reverse primer
+		{"clip", 'p'},
 		{"cut3", 'e'},
 		{"qiime", '#'},
 		{"intelligent", 'i'},
@@ -775,6 +781,21 @@ int cParameter::GetOpt(int argc, char *argv[], char * errMsg)
 			break;
 		case 'e':
 			bCutTail = true;
+			break;
+		case 'p':
+			{
+				char * line = strdup(argv[i]);
+				char * num1 = strtok(line, ",");
+				char * num2 = strtok(NULL, ",");
+				iClip1 = atoi(num1);
+				if (num2 == NULL) {
+					iClip2 = 0;
+				}
+				else {
+					iClip2 = atoi(num2);
+				}
+			}
+			bClipTail = true;
 			break;
 		case '1':
 			bStdout = true;

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -119,6 +119,8 @@ public:
 	int minK;
 	int iCutF, iCutR;
 	bool bCutTail;
+	bool bClipTail;
+	int iClip1, iClip2;
 	bool bFillWithNs;
 
 private:


### PR DESCRIPTION
In some applications, it is necessary to hard-clip the 3' end of reads regardless of quality or overall read length. A key example of this is bisulfite sequencing: the 2 3' bases of read 2 are biased due to the end repair process (https://sequencing.qcfail.com/articles/library-end-repair-reaction-introduces-methylation-biases-in-paired-end-pe-bisulfite-seq-applications/). I added an option (--clip) that performs hard-clipping after adapter trimming but before any quality trimming.