### PR TITLE
Exit gracefully when requesting version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2601,9 +2601,10 @@ int main(int argc, char * argv[])
 		char * program = strrchr(argv[0], '/');
 		program = (program == NULL) ? argv[0] : (program + 1);
 		if(iRet == -1){
-			if(para.bEnquireVersion)
+			if(para.bEnquireVersion){
 				para.PrintVersion(stdout);
 				return 0;
+			}
 			else
 				para.PrintUsage(program, stdout);
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2603,6 +2603,7 @@ int main(int argc, char * argv[])
 		if(iRet == -1){
 			if(para.bEnquireVersion)
 				para.PrintVersion(stdout);
+				return 0;
 			else
 				para.PrintUsage(program, stdout);
 		}


### PR DESCRIPTION
This enables a compile to be tested with `skewer -v` and have it return gracefully (as is common practice when printing version)