### PR TITLE
fixed a bug in Makefile making object compilation with linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CXX=g++
 DEBUG?=0
-CXXFLAGS?=-c
 LDFLAGS=-pthread
 LDLIBS=-lrt
 ifneq ($(OS), Windows_NT)
@@ -32,7 +31,7 @@ $(EXECUTABLE):$(OBJECTS)
 	$(CXX) $(LDFLAGS) $(OBJECTS) -o $@ $(LDLIBS)
 
 .cpp.o:
-	$(CXX) $(CXXFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(SRC)/main.o: $(SRC)/parameter.h $(SRC)/matrix.h $(SRC)/fastq.h $(SRC)/common.h
 $(SRC)/parameter.o: $(SRC)/parameter.h $(SRC)/fastq.h $(SRC)/common.h


### PR DESCRIPTION
In the Makefile the `CXXFLAGS` is modified with the `?=`operator to add the `-c` flag to g++.

This operator is adding only if `CXXFLAGS` is not yet defined, which the case when producing a package (Archlinux), causing the `-c` flag to be skipped.

As  `-c` flag is mandatory for proper compilation, this patch add it directly on the g++ command line.

See [Skewer Archlinux package](https://aur.archlinux.org/packages/skewer/)

Please consider applying this patch. Comments are welcome. Thanks
