### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -324,7 +324,7 @@ void gzstrncpy (char * dest, const char * src, int n)
 
 void versatile_gettime(struct timespec *tp)
 {
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 	static double orwl_timebase = 0.0;
 	static uint64_t orwl_timestart = 0; 
 	if(!orwl_timestart){

--- a/src/fastq.h
+++ b/src/fastq.h
@@ -46,7 +46,7 @@
 #include <limits.h>
 
 #include <time.h>
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/mach_time.h>
 #define ORWL_NANO (+1.0E-9)
 #define ORWL_GIGA UINT64_C(1000000000)


### PR DESCRIPTION
Hurd also uses Mach, but does not have the same shortcomings as OSX in this area.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```